### PR TITLE
promote: dev to main after historical metrics README update

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,9 +8,11 @@
 ![suite](https://img.shields.io/badge/suite-Reporium-6e40c9)
 <!-- perditio-badges-end -->
 
-> Platform performance tracking. Verified numbers only — no estimates.
+> Platform performance tracking. Verified numbers only, no estimates.
 
-## Current Stats
+This README is a historical snapshot of the metrics state captured on 2026-03-20. It should not be treated as the current live suite total without regenerating the metrics artifacts.
+
+## Historical Snapshot: 2026-03-20
 
 | Metric | Value |
 |--------|-------|
@@ -18,8 +20,8 @@
 | Repos tracked (reporium-db) | 1,573 |
 | Languages tracked | 39 |
 | Categories enriched | 0 |
-| Repos in API DB | — |
-| Languages (API) | — |
+| Repos in API DB | - |
+| Languages (API) | - |
 | forksync sync duration | 143s (v1) |
 | forksync repos checked | 792 |
 | forksync repos synced | 0 |
@@ -33,10 +35,12 @@
 - reporium-api — deployed to Cloud Run (metrics not yet collected)
 
 ### Not Working
-- reporium-ingestion — pipeline not running, 0 categories enriched
-- AI categories — requires ingestion pipeline to generate real categorization
+- reporium-ingestion: pipeline not running, 0 categories enriched
+- AI categories: required the ingestion pipeline to generate real categorization
 
 ## Trends
+
+These trend points reflect the March 2026 metrics history preserved in this file.
 
 ### Repos Tracked Over Time
 ```
@@ -54,27 +58,28 @@
 
 ## Milestones
 
+The milestones below are preserved as dated platform milestones, not current state assertions.
+
 | Date | Achievement |
 |------|-------------|
-| 2026-03-20 | **reporium-api deployed to Cloud Run — 826 repos accessible via public REST API** |
+| 2026-03-20 | **reporium-api deployed to Cloud Run - 826 repos accessible via public REST API at that milestone** |
 | 2026-03-20 | Neon PostgreSQL (pgvector) provisioned, all 13 tables migrated |
-| 2026-03-20 | reporium-events Pub/Sub system live, forksync + reporium-db publishing events |
+| 2026-03-20 | reporium-events Pub/Sub system planned and partially wired, with forksync + reporium-db as intended publishers at that milestone |
 | 2026-03-20 | reporium-audit nightly health checks, perditio-devkit shared tooling |
 | 2026-03-20 | Reporium suite badges and build counters on all repos |
-| 2026-03-17 | **forksync v2 launched on Cloud Run — 68s for 818 repos, 91% faster than v1 (was 13 min)** |
+| 2026-03-17 | **forksync v2 launched on Cloud Run - 68s for 818 repos, 91% faster than v1 (was 13 min)** |
 | 2026-03-17 | Cloud Run + Redis + VPC connector deployed for forksync |
-
 
 ## Architecture Decisions
 
 | Decision | Rationale |
 |----------|-----------|
-| GraphQL over REST | REST API required 826 individual calls. GraphQL batch does it in 9. |
+| GraphQL over REST | At the March 2026 launch scale, REST API required 826 individual calls. GraphQL batch did it in 9. |
 | Cloud Run for forksync | GitHub Actions timeout at 6min could not support 13min v1 runtime. |
 | Redis for caching | ETag caching reduces redundant compare API calls. |
 | Neon over Cloud SQL | Cloud SQL costs $7-10/month minimum. Neon free tier supports pgvector. |
-| Partitioned JSON | Single dataset.json would be 50MB+ at 100K repos. Partitioned files let frontend load only what it needs. |
-| Pub/Sub events | Decouples services — forksync and reporium-db publish events, API and audit consume them. |
+| Partitioned JSON | Single `dataset.json` would be 50MB+ at 100K repos. Partitioned files let the frontend load only what it needs. |
+| Pub/Sub events | Intended to decouple services; forksync and reporium-db were the planned publishers at this milestone, while downstream consumer integration was still evolving. |
 
 ---
-*Last updated: 2026-03-31 · Data from live GitHub sources.*
+*Historical snapshot last updated: 2026-03-20. Regenerate metrics artifacts before treating these values as current live state.*


### PR DESCRIPTION
## Summary
- Promote validated dev changes to main
- Includes README historical framing for March 2026 metrics and pre-expansion counts

## Included work
- reporium-metrics #1
- Merged via PR #2 into dev

## Validation
- python -m pytest tests -q passed
- Remaining 826-repo references were reviewed and kept as historical-only context

## Notes
- This promotion updates documentation only