### PR TITLE
fix: add psycopg2-binary to requirements (CI broken since Apr 8)

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,5 @@
 httpx>=0.27
+psycopg2-binary>=2.9
 python-dotenv>=1.0
 pytest>=8.0
 pytest-asyncio>=0.23


### PR DESCRIPTION
## Summary
- `collect.py` imports `psycopg2` at module level but it was missing from `requirements.txt`
- This caused all `Tests` CI runs to fail with `ImportError: No module named 'psycopg2'` since the April 8 CHANGELOG commit
- Adding `psycopg2-binary>=2.9` fixes the collection step — tests can now import `collect.py`

## Test plan
- [ ] CI passes after this change
- [ ] All 14 test cases in `tests/test_collect.py` run successfully

🤖 Generated with [Claude Code](https://claude.com/claude-code)