### PR TITLE
KAN-186: SHA-pin GitHub Actions in reporium-metrics

### DIFF
--- a/.github/workflows/collect.yml
+++ b/.github/workflows/collect.yml
@@ -14,10 +14,10 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
 
       - name: Set up Python
-        uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065
+        uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5.6.0
         with:
           python-version: "3.11"
 

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -12,10 +12,10 @@ jobs:
   security:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
           fetch-depth: 20
-      - uses: actions/setup-python@v5
+      - uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5.6.0
         with:
           python-version: "3.11"
       - run: pip install git+https://github.com/perditioinc/reporium-security.git

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -14,10 +14,10 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
 
       - name: Set up Python
-        uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065
+        uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5.6.0
         with:
           python-version: "3.11"
 


### PR DESCRIPTION
## Summary
Pin all third-party GitHub Actions to commit SHAs (KAN-186, mirrors KAN-163 + KAN-171 precedent). Prevents supply-chain attacks where mutable version tags (`@v5`) could be repointed at malicious commits.

## Pins applied

### `.github/workflows/security.yml`
| Action | Before | After |
|---|---|---|
| `actions/setup-python` | `@v5` | `@a26af69be951a213d495a4c3e4e4022e16d87065  # v5.6.0` |
| `actions/checkout` | `@11bd71...` (already SHA) | `@11bd71...  # v4.2.2` (added comment) |

### `.github/workflows/collect.yml`
| Action | Before | After |
|---|---|---|
| `actions/checkout` | `@11bd71...` (already SHA) | `@11bd71...  # v4.2.2` (added comment) |
| `actions/setup-python` | `@a26af69...` (already SHA) | `@a26af69...  # v5.6.0` (added comment) |

### `.github/workflows/test.yml`
| Action | Before | After |
|---|---|---|
| `actions/checkout` | `@11bd71...` (already SHA) | `@11bd71...  # v4.2.2` (added comment) |
| `actions/setup-python` | `@a26af69...` (already SHA) | `@a26af69...  # v5.6.0` (added comment) |

## Out of scope
- `perditioinc/perditio-devkit/.github/workflows/on-test-failure.yml@main` — own-org reusable workflow, left as-is per KAN-171 precedent.

## Test plan
- [ ] PR CI (test.yml) green on this PR

JIRA: https://perditio.atlassian.net/browse/KAN-186