### PR TITLE
local: $0 OSS dev substrate (docker-compose + stub + smoke)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,25 @@
+# Root passthrough to the local OSS substrate (local/).
+# Additive, local only, $0. Does not touch production or CI.
+#
+#   make local-up      start Postgres + stub, wait for healthy
+#   make local-seed    show seeded knowledge-graph edge counts
+#   make local-smoke   run real collect.py + generate.py against local stubs
+#   make local-down    stop containers (keep volumes)
+#   make local-clean   full teardown including volumes
+
+.PHONY: local-up local-seed local-smoke local-down local-clean
+
+local-up:
+	$(MAKE) -C local up
+
+local-seed:
+	$(MAKE) -C local seed
+
+local-smoke:
+	$(MAKE) -C local smoke
+
+local-down:
+	$(MAKE) -C local down
+
+local-clean:
+	$(MAKE) -C local clean

--- a/local/.env.example
+++ b/local/.env.example
@@ -1,0 +1,16 @@
+# Local OSS substrate config. Copy to .env to override defaults.
+# Every value below already has a working default baked into docker-compose.yml,
+# so the substrate runs with NO secrets and NO edits out of the box.
+
+# App config (the same env vars collect.py reads in production):
+GH_TOKEN=local-stub-token
+REPORIUM_API_URL=http://stub:8080
+FORKSYNC_REPO=perditioinc/forksync
+REPORIUM_DB_REPO=perditioinc/reporium-db
+
+# Smoke-only wiring (read by local/smoke.py, not by the app in production):
+# GITHUB_RAW_BASE is a module constant in collect.py, not an env var the app
+# exposes; the smoke runner redirects it to the local stub. This is the single
+# piece of wiring the app does not surface as configuration.
+GITHUB_RAW_BASE=http://stub:8080
+SMOKE_WORK=/work

--- a/local/Makefile
+++ b/local/Makefile
@@ -1,0 +1,35 @@
+# Local OSS substrate for reporium-metrics. $0, additive, local only.
+# Usage: make up | seed | smoke | down | clean
+#
+# Run from this directory (local/) or via the root passthrough: `make -C local <target>`.
+
+COMPOSE := docker compose
+
+.PHONY: up down seed smoke clean logs
+
+## up: start the stub service and wait until it is healthy
+up:
+	$(COMPOSE) up --wait stub
+
+## seed: no external datastore on this branch; the stub serves fixed fixtures.
+##       This target prints the fixtures the stub will return so a run is reproducible.
+seed:
+	$(COMPOSE) up --wait stub
+	@echo "Stub fixtures (served at http://stub:8080):"
+	$(COMPOSE) exec -T stub python -c "import stub_server,json; print('SYNC_REPORT.md repos_synced=201, duration=68'); print('index.json:', json.dumps(stub_server.INDEX_JSON['meta'])); print('/metrics/latest:', json.dumps(stub_server.METRICS_LATEST))"
+
+## smoke: run the real collect.py + generate.py path against the local stub
+smoke:
+	$(COMPOSE) run --rm smoke
+
+## logs: tail substrate logs
+logs:
+	$(COMPOSE) logs -f
+
+## down: stop and remove containers (keeps named volumes)
+down:
+	$(COMPOSE) down
+
+## clean: full teardown including volumes
+clean:
+	$(COMPOSE) down -v

--- a/local/README.md
+++ b/local/README.md
@@ -1,0 +1,69 @@
+# Local OSS Substrate
+
+A self-contained, `$0`, OSS-only dev substrate that lets you run the real
+`collect.py` + `generate.py` path on your machine with no cloud access and no
+secrets. Additive and local only -- it never touches production, CI, or any
+live cloud resource, and it mounts the source checkout **read-only** so a run
+can never mutate your working tree.
+
+## What it replaces
+
+On this branch `collect.py` reaches two live cloud surfaces. Each gets a local
+OSS stand-in:
+
+| Live cloud dependency | What collect.py does | Local OSS substitute |
+|-----------------------|----------------------|----------------------|
+| GitHub raw (`raw.githubusercontent.com`) | fetch `forksync/main/SYNC_REPORT.md` and `reporium-db/main/data/index.json` | stdlib `http.server` stub (`local/stubs/stub_server.py`) serving both paths, with the report date templated to today (UTC) |
+| reporium-api (Cloud Run) via `REPORIUM_API_URL` | `GET /metrics/latest` | same stub, returning the same JSON contract |
+
+The stub is stdlib-only (no pip installs) and the smoke runner installs only the
+app's own `requirements.txt`. Everything is free and runs fully offline.
+
+## Quick start
+
+From this directory (`local/`):
+
+```sh
+make up      # start the stub, wait until healthy
+make seed    # print the fixtures the stub will serve
+make smoke   # run the real collect.py + generate.py path against the stub
+make clean   # full teardown (containers + volumes)
+```
+
+Or from the repo root via the passthrough:
+
+```sh
+make local-up
+make local-smoke
+make local-clean
+```
+
+## How the wiring works
+
+Everything is plain env config that the app already reads -- `REPORIUM_API_URL`,
+`FORKSYNC_REPO`, `REPORIUM_DB_REPO` -- pointed at the local stub in
+`docker-compose.yml`.
+
+The one exception is `GITHUB_RAW_BASE`, which `collect.py` defines as a module
+constant rather than an env var. Rather than edit the app, the smoke runner
+(`local/smoke.py`) redirects that single constant to the local stub at runtime.
+This is the only piece of wiring not exposed as configuration, and it lives
+entirely in the smoke runner, not in the application source.
+
+## The smoke test
+
+`local/smoke.py` drives the unmodified `collect.collect()` and
+`generate.build_readme()` functions end to end and asserts on the real output:
+
+- forksync metrics (duration, repos_synced) parsed from the stubbed `SYNC_REPORT.md`
+- reporium-db `repos_tracked` / `languages` / `categories_enriched` parsed from `index.json`
+- reporium-api `/metrics/latest` captured
+- `metrics.json` persisted and `README.md` rendered from it
+
+Outputs are written to a named volume (`/work`), never the read-only checkout.
+Exit `0` = PASS.
+
+## Config
+
+Defaults are baked into `docker-compose.yml`, so nothing is required. To override,
+copy `.env.example` to `.env`.

--- a/local/docker-compose.yml
+++ b/local/docker-compose.yml
@@ -1,0 +1,60 @@
+# Local OSS substrate for reporium-metrics.
+# $0, additive, local only. Mirrors the live cloud dependencies this branch's
+# collect.py reaches, with OSS stand-ins:
+#
+#   live reporium-api (Cloud Run)       ->  stub (stdlib http.server) /metrics/latest
+#   live GitHub raw (githubusercontent) ->  same stub, serves SYNC_REPORT.md + index.json
+#
+# The source checkout is mounted READ-ONLY into the smoke runner so a run can
+# never mutate the working tree; outputs go to a named volume instead.
+
+name: reporium-metrics-local
+
+services:
+  # One container stands in for BOTH reporium-api and GitHub raw (stdlib only).
+  stub:
+    image: python:3.11-slim
+    working_dir: /stub
+    volumes:
+      - ./stubs:/stub:ro
+    command: ["python", "stub_server.py"]
+    healthcheck:
+      test:
+        ["CMD-SHELL", "python -c \"import urllib.request; urllib.request.urlopen('http://localhost:8080/healthz')\""]
+      interval: 3s
+      timeout: 3s
+      retries: 20
+
+  # Smoke runner: real collect.py + generate.py path against the stub above.
+  smoke:
+    image: python:3.11-slim
+    depends_on:
+      stub:
+        condition: service_healthy
+    working_dir: /app
+    environment:
+      # App config (env the app already reads):
+      GH_TOKEN: local-stub-token
+      REPORIUM_API_URL: http://stub:8080
+      FORKSYNC_REPO: perditioinc/forksync
+      REPORIUM_DB_REPO: perditioinc/reporium-db
+      # Smoke wiring (read by local/smoke.py only):
+      GITHUB_RAW_BASE: http://stub:8080
+      SMOKE_WORK: /work
+      PYTHONPATH: /app
+    volumes:
+      - ../:/app:ro          # source checkout, READ-ONLY
+      - ./smoke.py:/smoke.py:ro
+      - smoke_out:/work       # writable scratch for metrics.json / README.md
+    # Install the app's own requirements, then run the real path via the smoke runner.
+    command:
+      - /bin/sh
+      - -c
+      - |
+        set -e
+        pip install --quiet --no-cache-dir -r /app/requirements.txt
+        python /smoke.py
+    profiles: ["smoke"]
+
+volumes:
+  smoke_out:

--- a/local/smoke.py
+++ b/local/smoke.py
@@ -1,0 +1,112 @@
+"""Smoke test: exercise collect.py + generate.py real path against local OSS stubs.
+
+This is a thin runner, NOT an app edit. The checkout is mounted read-only, so:
+  - we import the real collect/generate modules unchanged
+  - we redirect GITHUB_RAW_BASE (a module constant, not an env var) to the local
+    stub via a one-line monkeypatch -- the single piece of wiring the app does
+    not expose as configuration
+  - everything else (REPORIUM_API_URL, FORKSYNC_REPO, REPORIUM_DB_REPO) is plain
+    env config the app already reads
+  - metrics.json / README.md are written into a writable /work dir, never the
+    read-only source checkout
+
+Exit 0 = PASS, non-zero = FAIL.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import os
+import sys
+from pathlib import Path
+
+WORK = Path(os.environ["SMOKE_WORK"])  # writable scratch, set by compose
+WORK.mkdir(parents=True, exist_ok=True)
+METRICS = WORK / "metrics.json"
+README = WORK / "README.md"
+
+# Start each run clean so the duplicate-date guard does not short-circuit.
+if METRICS.exists():
+    METRICS.unlink()
+METRICS.write_text("[]", encoding="utf-8")
+
+import collect  # noqa: E402  (import after env is set up)
+import generate  # noqa: E402
+
+# --- the one bit of wiring the app does not expose as env config -------------
+collect.GITHUB_RAW_BASE = os.environ["GITHUB_RAW_BASE"]
+# Point both modules at the writable metrics file.
+collect.METRICS_FILE = METRICS
+generate.METRICS_FILE = METRICS
+# ----------------------------------------------------------------------------
+
+failures: list[str] = []
+
+
+def check(cond: bool, msg: str) -> None:
+    status = "PASS" if cond else "FAIL"
+    print(f"[{status}] {msg}")
+    if not cond:
+        failures.append(msg)
+
+
+async def run() -> None:
+    token = os.environ.get("GH_TOKEN", "local-stub-token")
+
+    # 1. Real collect path against local stubs (GitHub raw + reporium-api)
+    entry = await collect.collect(token)
+    check(entry is not None, "collect() returned a new entry")
+    if entry is None:
+        return
+
+    # 2. GitHub-raw forksync surface parsed from stubbed SYNC_REPORT.md
+    fs1 = entry["forksync_v1"]
+    check(
+        fs1 is not None and fs1["duration_seconds"] == 68,
+        "forksync_v1 parsed from stubbed SYNC_REPORT.md (duration=68)",
+    )
+    check(
+        fs1 is not None and fs1["repos_synced"] == 201,
+        "forksync_v1 repos_synced=201",
+    )
+
+    # 3. GitHub-raw reporium-db surface parsed from stubbed index.json
+    db = entry["reporium_db"]
+    check(db is not None and db["repos_tracked"] == 1939, "reporium_db repos_tracked=1939")
+    check(db is not None and db["languages"] == 41, "reporium_db languages=41")
+    check(
+        db is not None and db["categories_enriched"] == 2,
+        "categories_enriched=2 (tooling/unknown excluded)",
+    )
+
+    # 4. reporium-api /metrics/latest surface captured
+    api = entry["reporium_api"]
+    check(api is not None and api["repos_tracked"] == 1732, "reporium_api /metrics/latest captured")
+
+    # 5. metrics.json persisted exactly one entry
+    persisted = json.loads(METRICS.read_text(encoding="utf-8"))
+    check(len(persisted) == 1, "metrics.json persisted exactly one entry")
+
+    # 6. Real generate path renders README from collected metrics
+    entries = generate.load_metrics(METRICS)
+    readme = generate.build_readme(entries)
+    README.write_text(readme, encoding="utf-8")
+    check("# Reporium Metrics" in readme, "generate.build_readme produced README")
+    check("1,939" in readme, "README reflects collected repos_tracked (1,939)")
+
+
+def main() -> int:
+    asyncio.run(run())
+    print()
+    if failures:
+        print(f"SMOKE RESULT: FAIL ({len(failures)} check(s) failed)")
+        for f in failures:
+            print(f"  - {f}")
+        return 1
+    print("SMOKE RESULT: PASS")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/local/stubs/stub_server.py
+++ b/local/stubs/stub_server.py
@@ -1,0 +1,88 @@
+"""Single-file OSS stub for every HTTP dependency collect.py reaches.
+
+Stands in for the two live cloud surfaces collect.py uses on this branch
+(stdlib only -- $0, no pip installs, runs fully offline):
+
+1. GitHub raw  (https://raw.githubusercontent.com/<repo>/main/<path>)
+     GET /perditioinc/forksync/main/SYNC_REPORT.md
+     GET /perditioinc/reporium-db/main/data/index.json
+   The smoke runner redirects collect.GITHUB_RAW_BASE here.
+
+2. reporium-api  (the Cloud Run service behind REPORIUM_API_URL)
+     GET /metrics/latest
+
+Dates are templated to "today" (UTC) so collect.py's prior-month skip and
+duplicate-date guards behave exactly as they would against live sources.
+"""
+
+from __future__ import annotations
+
+import json
+from datetime import datetime, timezone
+from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
+from urllib.parse import urlparse
+
+TODAY = datetime.now(timezone.utc).strftime("%Y-%m-%d")
+TODAY_ISO = datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%S+00:00")
+
+SYNC_REPORT = f"""# Fork Sync Report
+**perditioinc's GitHub Forks** · {TODAY} 12:00 UTC · 68s
+
+## Machine-readable fields
+- date: {TODAY}
+- duration_seconds: 68
+- repos_checked: 818
+- repos_synced: 201
+- already_current: 265
+- api_calls_used: 937
+- errors: 0
+- peak_concurrency: 50
+"""
+
+INDEX_JSON = {
+    "meta": {"total": 1939, "last_updated": TODAY_ISO, "version": "1.0.0"},
+    "categories": {"llm": 300, "rag": 100, "tooling": 800, "unknown": 50},
+    "languages": {f"lang{i}": 10 for i in range(41)},
+}
+
+METRICS_LATEST = {
+    "repos_tracked": 1732,
+    "languages": 40,
+    "source": "reporium-api /metrics/latest",
+}
+
+
+class Handler(BaseHTTPRequestHandler):
+    def _send(self, code: int, body: str, content_type: str) -> None:
+        payload = body.encode("utf-8")
+        self.send_response(code)
+        self.send_header("Content-Type", content_type)
+        self.send_header("Content-Length", str(len(payload)))
+        self.end_headers()
+        self.wfile.write(payload)
+
+    def _json(self, code: int, obj: object) -> None:
+        self._send(code, json.dumps(obj), "application/json")
+
+    def do_GET(self) -> None:  # noqa: N802
+        path = urlparse(self.path).path
+
+        if path == "/perditioinc/forksync/main/SYNC_REPORT.md":
+            self._send(200, SYNC_REPORT, "text/plain; charset=utf-8")
+        elif path == "/perditioinc/reporium-db/main/data/index.json":
+            self._json(200, INDEX_JSON)
+        elif path == "/metrics/latest":
+            self._json(200, METRICS_LATEST)
+        elif path == "/healthz":
+            self._json(200, {"ok": True})
+        else:
+            self._json(404, {"error": "not found", "path": path})
+
+    def log_message(self, fmt: str, *args: object) -> None:
+        print("stub %s - %s" % (self.address_string(), fmt % args))
+
+
+if __name__ == "__main__":
+    server = ThreadingHTTPServer(("0.0.0.0", 8080), Handler)
+    print(f"stub_server listening on :8080 (date={TODAY})")
+    server.serve_forever()


### PR DESCRIPTION
## Summary

Adds a self-contained `local/` OSS dev substrate so anyone can run the real
`collect.py` + `generate.py` path on their machine with **no cloud access and no
secrets**. Additive and local only: no changes to application source, production,
or CI. The source checkout is mounted **read-only** in the smoke runner, so a run
can never mutate the working tree.

Validated end to end with Docker (see below).

## Substrate

| File | Purpose |
|------|---------|
| `local/docker-compose.yml` | one stub service (`python:3.11-slim`) + a smoke runner |
| `local/stubs/stub_server.py` | stdlib-only HTTP stub for both cloud surfaces |
| `local/smoke.py` | thin runner exercising the real collect + generate path |
| `local/Makefile` | `up` / `seed` / `smoke` / `down` / `clean` |
| `Makefile` (root) | passthrough: `local-up` / `local-seed` / `local-smoke` / `local-down` / `local-clean` |
| `local/.env.example` | config (all values default in compose; nothing required) |
| `local/README.md` | docs |

## Cloud -> OSS map

This branch's `collect.py` reaches two live cloud surfaces. Each gets a local OSS
stand-in (the stub serves both):

| Live cloud dependency | What `collect.py` does | Local OSS substitute |
|-----------------------|------------------------|----------------------|
| GitHub raw (`raw.githubusercontent.com`) | fetch `forksync/main/SYNC_REPORT.md` and `reporium-db/main/data/index.json` | stdlib `http.server` stub serving both paths, report date templated to today (UTC) so the prior-month/duplicate-date guards behave like live |
| reporium-api (Cloud Run) via `REPORIUM_API_URL` | `GET /metrics/latest` | same stub, same JSON contract |

Wiring is plain env config the app already reads (`REPORIUM_API_URL`,
`FORKSYNC_REPO`, `REPORIUM_DB_REPO`). The single exception is `GITHUB_RAW_BASE`,
which `collect.py` defines as a module constant rather than an env var; the smoke
runner redirects that one constant to the stub at runtime instead of editing the
app. Documented in `local/README.md`.

## Validation

`docker compose up --wait` -> `smoke` -> `down -v`, all green:

```
[PASS] collect() returned a new entry
[PASS] forksync_v1 parsed from stubbed SYNC_REPORT.md (duration=68)
[PASS] forksync_v1 repos_synced=201
[PASS] reporium_db repos_tracked=1939
[PASS] reporium_db languages=41
[PASS] categories_enriched=2 (tooling/unknown excluded)
[PASS] reporium_api /metrics/latest captured
[PASS] metrics.json persisted exactly one entry
[PASS] generate.build_readme produced README
[PASS] README reflects collected repos_tracked (1,939)

SMOKE RESULT: PASS
```

The smoke drives the unmodified `collect.collect()` and `generate.build_readme()`;
outputs go to a named volume, never the read-only checkout. `git status` after a
full run shows only the additive `local/` + root `Makefile`, no tracked file modified.

## Properties

- **Additive / local / \$0**: OSS only (`python:3.11-slim` + stdlib), no paid
  services, no secrets, runs fully offline.
- No production or CI edits; no application source edits.
- Mounts source read-only; clean teardown via `make clean` (`down -v`).

## Notes

- Built against the **dev** integration branch's real path, which uses only
  GitHub raw + `reporium-api /metrics/latest` (no Postgres/`DATABASE_URL` on this
  branch, unlike `main`).
- No bug found in the application code during this work.

Refs perditioinc/reporium-system-design#5 (card #6).

Awaiting human review. Not self-merged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)