### PR TITLE
fix: repair CP1252 em-dash mojibake; pin ASCII output + no-data fidelity

### DIFF
--- a/MILESTONES.md
+++ b/MILESTONES.md
@@ -1,9 +1,9 @@
 | Date | Achievement |
 |------|-------------|
-| 2026-03-20 | **reporium-api deployed to Cloud Run — 826 repos accessible via public REST API** |
+| 2026-03-20 | **reporium-api deployed to Cloud Run -- 826 repos accessible via public REST API** |
 | 2026-03-20 | Neon PostgreSQL (pgvector) provisioned, all 13 tables migrated |
 | 2026-03-20 | reporium-events Pub/Sub system live, forksync + reporium-db publishing events |
 | 2026-03-20 | reporium-audit nightly health checks, perditio-devkit shared tooling |
 | 2026-03-20 | Reporium suite badges and build counters on all repos |
-| 2026-03-17 | **forksync v2 launched on Cloud Run — 68s for 818 repos, 91% faster than v1 (was 13 min)** |
+| 2026-03-17 | **forksync v2 launched on Cloud Run -- 68s for 818 repos, 91% faster than v1 (was 13 min)** |
 | 2026-03-17 | Cloud Run + Redis + VPC connector deployed for forksync |

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@
 ![suite](https://img.shields.io/badge/suite-Reporium-6e40c9)
 <!-- perditio-badges-end -->
 
-> Platform performance tracking. Verified numbers only â€” no estimates.
+> Platform performance tracking. Verified numbers only -- no estimates.
 
 ## Current Stats
 
@@ -18,23 +18,23 @@
 | Repos tracked (reporium-db) | 1,945 |
 | Languages tracked | 41 |
 | Categories enriched | 0 |
-| Repos in API DB | â€” |
-| Languages (API) | â€” |
+| Repos in API DB | -- |
+| Languages (API) | -- |
 | forksync sync duration | no data |
-| forksync repos checked | â€” |
-| forksync repos synced | â€” |
+| forksync repos checked | -- |
+| forksync repos synced | -- |
 
 ## Status
 
 ### Working
-- reporium.com â€” live, repos browseable
-- reporium-db â€” nightly sync active, 1945 repos tracked, 41 languages
-- forksync v2 â€” running on Cloud Run (no SYNC_REPORT.md data available)
-- reporium-api â€” deployed to Cloud Run (metrics not yet collected)
+- reporium.com -- live, repos browseable
+- reporium-db -- nightly sync active, 1945 repos tracked, 41 languages
+- forksync v2 -- running on Cloud Run (no SYNC_REPORT.md data available)
+- reporium-api -- deployed to Cloud Run (metrics not yet collected)
 
 ### Not Working
-- reporium-ingestion â€” pipeline not running, 0 categories enriched
-- AI categories â€” requires ingestion pipeline to generate real categorization
+- reporium-ingestion -- pipeline not running, 0 categories enriched
+- AI categories -- requires ingestion pipeline to generate real categorization
 
 ## Trends
 
@@ -56,12 +56,12 @@
 
 | Date | Achievement |
 |------|-------------|
-| 2026-03-20 | **reporium-api deployed to Cloud Run — 826 repos accessible via public REST API** |
+| 2026-03-20 | **reporium-api deployed to Cloud Run -- 826 repos accessible via public REST API** |
 | 2026-03-20 | Neon PostgreSQL (pgvector) provisioned, all 13 tables migrated |
 | 2026-03-20 | reporium-events Pub/Sub system live, forksync + reporium-db publishing events |
 | 2026-03-20 | reporium-audit nightly health checks, perditio-devkit shared tooling |
 | 2026-03-20 | Reporium suite badges and build counters on all repos |
-| 2026-03-17 | **forksync v2 launched on Cloud Run — 68s for 818 repos, 91% faster than v1 (was 13 min)** |
+| 2026-03-17 | **forksync v2 launched on Cloud Run -- 68s for 818 repos, 91% faster than v1 (was 13 min)** |
 | 2026-03-17 | Cloud Run + Redis + VPC connector deployed for forksync |
 
 
@@ -74,7 +74,7 @@
 | Redis for caching | ETag caching reduces redundant compare API calls. |
 | Neon over Cloud SQL | Cloud SQL costs $7-10/month minimum. Neon free tier supports pgvector. |
 | Partitioned JSON | Single dataset.json would be 50MB+ at 100K repos. Partitioned files let frontend load only what it needs. |
-| Pub/Sub events | Decouples services â€” forksync and reporium-db publish events, API and audit consume them. |
+| Pub/Sub events | Decouples services -- forksync and reporium-db publish events, API and audit consume them. |
 
 ---
-*Last updated: 2026-06-13 Â· Data from live GitHub sources.*
+*Last updated: 2026-06-13 - Data from live GitHub sources.*

--- a/collect.py
+++ b/collect.py
@@ -140,7 +140,7 @@ def parse_index_json(data: dict) -> dict[str, Any]:
         "languages": len(languages),
         "categories_enriched": categories_enriched,
         "last_updated": meta.get("last_updated"),
-        "source": "data/index.json â€” live",
+        "source": "data/index.json -- live",
     }
 
 
@@ -179,7 +179,7 @@ async def collect(token: str) -> Optional[dict[str, Any]]:
     entries = load_metrics(METRICS_FILE)
 
     if any(e.get("date") == today for e in entries):
-        logger.info("Today's entry (%s) already exists â€” skipping", today)
+        logger.info("Today's entry (%s) already exists -- skipping", today)
         return None
 
     t0 = time.monotonic()
@@ -192,19 +192,19 @@ async def collect(token: str) -> Optional[dict[str, Any]]:
         if parsed:
             if report_date and report_date[:7] < today[:7]:
                 logger.info(
-                    "SYNC_REPORT.md is from %s (prior month, today %s) â€” skipping",
+                    "SYNC_REPORT.md is from %s (prior month, today %s) -- skipping",
                     report_date,
                     today,
                 )
             else:
                 forksync_v1 = parsed
-                forksync_v1["source"] = "SYNC_REPORT.md â€” live"
+                forksync_v1["source"] = "SYNC_REPORT.md -- live"
                 logger.info("Parsed SYNC_REPORT.md (dated %s)", report_date or "unknown")
         else:
             logger.warning("SYNC_REPORT.md present but no parseable fields found")
 
     if forksync_v1 is None:
-        logger.warning("No fresh forksync data available â€” using null")
+        logger.warning("No fresh forksync data available -- using null")
 
     reporium_db: Optional[dict] = None
     index_text = await _fetch_raw(token, REPORIUM_DB_REPO, "data/index.json")
@@ -215,7 +215,7 @@ async def collect(token: str) -> Optional[dict[str, Any]]:
             logger.warning("Could not parse index.json: %s", exc)
 
     if reporium_db is None:
-        logger.warning("reporium-db index.json unavailable â€” using null")
+        logger.warning("reporium-db index.json unavailable -- using null")
 
     reporium_api: Optional[dict] = None
     backfill_metrics: Optional[dict] = None
@@ -228,7 +228,7 @@ async def collect(token: str) -> Optional[dict[str, Any]]:
             async with httpx.AsyncClient(timeout=TIMEOUT) as client:
                 reporium_api = await _fetch_json(client, f"{REPORIUM_API_URL}/metrics/latest")
                 if reporium_api is not None:
-                    reporium_api["source"] = "reporium-api /metrics/latest â€” live"
+                    reporium_api["source"] = "reporium-api /metrics/latest -- live"
                     logger.info(
                         "Fetched reporium-api metrics: %d repos tracked",
                         reporium_api.get("repos_tracked", 0),
@@ -236,17 +236,17 @@ async def collect(token: str) -> Optional[dict[str, Any]]:
 
                 backfill_metrics = await _fetch_json(client, f"{REPORIUM_API_URL}/metrics/backfill")
                 if backfill_metrics is not None:
-                    backfill_metrics["source"] = "reporium-api /metrics/backfill â€” live"
+                    backfill_metrics["source"] = "reporium-api /metrics/backfill -- live"
 
                 graph_quality = await _fetch_json(
                     client, f"{REPORIUM_API_URL}/metrics/graph-quality"
                 )
                 if graph_quality is not None:
-                    graph_quality["source"] = "reporium-api /metrics/graph-quality â€” live"
+                    graph_quality["source"] = "reporium-api /metrics/graph-quality -- live"
 
                 api_latency = await _fetch_json(client, f"{REPORIUM_API_URL}/metrics/latency")
                 if api_latency is not None:
-                    api_latency["source"] = "reporium-api /metrics/latency â€” live"
+                    api_latency["source"] = "reporium-api /metrics/latency -- live"
 
                 resp = await client.get(
                     f"{REPORIUM_API_URL}/graph/edges",
@@ -274,19 +274,19 @@ async def collect(token: str) -> Optional[dict[str, Any]]:
                     "total_edges": total,
                     "edge_type_counts": type_counts,
                     "depends_on_zero": depends_on_count == 0,
-                    "source": "reporium-api /graph/edges â€” live",
+                    "source": "reporium-api /graph/edges -- live",
                 }
                 if depends_on_count == 0:
                     logger.warning(
-                        "DEPENDS_ON edge count is 0 â€” repo_dependencies may be empty or "
+                        "DEPENDS_ON edge count is 0 -- repo_dependencies may be empty or "
                         "build_knowledge_graph.py has not been run since the fix"
                     )
                 else:
                     logger.info("Graph health: total=%d, DEPENDS_ON=%d", total, depends_on_count)
         except Exception as exc:  # noqa: BLE001
-            logger.warning("reporium-api unavailable: %s â€” using null", exc)
+            logger.warning("reporium-api unavailable: %s -- using null", exc)
     else:
-        logger.info("REPORIUM_API_URL not set â€” skipping API metrics")
+        logger.info("REPORIUM_API_URL not set -- skipping API metrics")
 
     edge_counts: Optional[dict[str, int]] = None
     if DATABASE_URL:
@@ -300,7 +300,7 @@ async def collect(token: str) -> Optional[dict[str, Any]]:
         except Exception as exc:  # noqa: BLE001
             logger.warning("Could not collect edge counts: %s", exc)
     else:
-        logger.info("DATABASE_URL not set â€” skipping edge count collection")
+        logger.info("DATABASE_URL not set -- skipping edge count collection")
 
     entry: dict[str, Any] = {
         "date": today,

--- a/generate.py
+++ b/generate.py
@@ -93,7 +93,7 @@ def _current_stats(entries: list[dict]) -> str:
     def _fmt(value: object) -> str:
         if isinstance(value, int):
             return f"{value:,}"
-        return str(value) if value is not None else "â€”"
+        return str(value) if value is not None else "--"
 
     if fs2.get("duration_seconds") is not None:
         duration = f"{fs2['duration_seconds']}s (v2)"
@@ -103,10 +103,10 @@ def _current_stats(entries: list[dict]) -> str:
         repos_checked = _fmt(fs1.get("repos_checked"))
     else:
         duration = "no data"
-        repos_checked = "â€”"
+        repos_checked = "--"
 
     rows = [
-        f"| Date | {latest.get('date', 'â€”')} |",
+        f"| Date | {latest.get('date', '--')} |",
         f"| Repos tracked (reporium-db) | {_fmt(db.get('repos_tracked'))} |",
         f"| Languages tracked | {_fmt(db.get('languages'))} |",
         f"| Categories enriched | {_fmt(db.get('categories_enriched'))} |",
@@ -115,7 +115,7 @@ def _current_stats(entries: list[dict]) -> str:
         f"| forksync sync duration | {duration} |",
         f"| forksync repos checked | {repos_checked} |",
         f"| forksync repos synced | {_fmt(fs1.get('repos_synced'))} |"
-        if fs1 else "| forksync repos synced | â€” |",
+        if fs1 else "| forksync repos synced | -- |",
     ]
 
     if backfill.get("available"):
@@ -145,35 +145,35 @@ def _status_section(entries: list[dict]) -> str:
     backfill = latest.get("backfill_metrics") or {}
 
     working = [
-        "reporium.com â€” live, repos browseable",
-        f"reporium-db â€” nightly sync active, {db.get('repos_tracked', 'â€”')} repos tracked, "
-        f"{db.get('languages', 'â€”')} languages",
+        "reporium.com -- live, repos browseable",
+        f"reporium-db -- nightly sync active, {db.get('repos_tracked', '--')} repos tracked, "
+        f"{db.get('languages', '--')} languages",
     ]
 
     if fs1.get("duration_seconds") is not None:
         working.append(
-            f"forksync v2 â€” {fs1['duration_seconds']}s for {fs1.get('repos_checked', 'â€”')} repos"
+            f"forksync v2 -- {fs1['duration_seconds']}s for {fs1.get('repos_checked', '--')} repos"
             " on Cloud Run, SYNC_REPORT.md committed via GitHub API"
         )
     else:
-        working.append("forksync v2 â€” running on Cloud Run (no SYNC_REPORT.md data available)")
+        working.append("forksync v2 -- running on Cloud Run (no SYNC_REPORT.md data available)")
 
     if api and api.get("repos_tracked") is not None:
         working.append(
-            f"reporium-api â€” deployed to Cloud Run, {api.get('repos_tracked', 'â€”')} repos, "
+            f"reporium-api -- deployed to Cloud Run, {api.get('repos_tracked', '--')} repos, "
             "Swagger UI public at /docs"
         )
     else:
-        working.append("reporium-api â€” deployed to Cloud Run (metrics not yet collected)")
+        working.append("reporium-api -- deployed to Cloud Run (metrics not yet collected)")
 
     if backfill.get("available"):
         working.append(
-            "dependency observability â€” backfill coverage and ETA exposed at /metrics/backfill"
+            "dependency observability -- backfill coverage and ETA exposed at /metrics/backfill"
         )
 
     not_working = [
-        "reporium-ingestion â€” pipeline not running, 0 categories enriched",
-        "AI categories â€” requires ingestion pipeline to generate real categorization",
+        "reporium-ingestion -- pipeline not running, 0 categories enriched",
+        "AI categories -- requires ingestion pipeline to generate real categorization",
     ]
 
     working_md = "\n".join(f"- {item}" for item in working)
@@ -221,10 +221,10 @@ def build_readme(entries: list[dict]) -> str:
 | Redis for caching | ETag caching reduces redundant compare API calls. |
 | Neon over Cloud SQL | Cloud SQL costs $7-10/month minimum. Neon free tier supports pgvector. |
 | Partitioned JSON | Single dataset.json would be 50MB+ at 100K repos. Partitioned files let frontend load only what it needs. |
-| Pub/Sub events | Decouples services â€” forksync and reporium-db publish events, API and audit consume them. |
+| Pub/Sub events | Decouples services -- forksync and reporium-db publish events, API and audit consume them. |
 """
 
-    generated = entries[-1].get("date", "â€”") if entries else "â€”"
+    generated = entries[-1].get("date", "n/a") if entries else "n/a"
 
     return f"""# Reporium Metrics
 
@@ -236,7 +236,7 @@ def build_readme(entries: list[dict]) -> str:
 ![suite](https://img.shields.io/badge/suite-Reporium-6e40c9)
 <!-- perditio-badges-end -->
 
-> Platform performance tracking. Verified numbers only â€” no estimates.
+> Platform performance tracking. Verified numbers only -- no estimates.
 
 ## Current Stats
 
@@ -251,7 +251,7 @@ def build_readme(entries: list[dict]) -> str:
 
 {decisions}
 ---
-*Last updated: {generated} Â· Data from live GitHub sources.*
+*Last updated: {generated} - Data from live GitHub sources.*
 """
 
 
@@ -265,7 +265,7 @@ def main() -> None:
         f.write(readme)
 
     elapsed = time.monotonic() - t0
-    logger.info("README generated in %.2fs â€” %d entries", elapsed, len(entries))
+    logger.info("README generated in %.2fs -- %d entries", elapsed, len(entries))
 
 
 if __name__ == "__main__":

--- a/tests/test_ascii_output.py
+++ b/tests/test_ascii_output.py
@@ -1,0 +1,64 @@
+"""Regression tests for ASCII-only output (CP1252 em-dash mojibake guard).
+
+The README and the metric `source` strings were corrupted at some point by a
+CP1252 round-trip: a real em-dash (U+2014) became the three-byte sequence
+E2 80 94, which decodes under UTF-8 to U+00E2 U+20AC U+201D and renders as
+mojibake. These tests pin generate.py's output and collect.py's literal strings
+to printable ASCII so the corruption cannot return.
+"""
+
+from __future__ import annotations
+
+import inspect
+
+import collect
+from generate import build_readme
+
+# The exact mojibake string, built from code points so this file stays ASCII.
+# CP1252 mis-decode of U+2014 -> bytes E2 80 94 -> UTF-8 U+00E2 U+20AC U+201D.
+MOJIBAKE = "\u00e2\u20ac\u201d"
+
+# Full block glyph (U+2588) used intentionally in the ASCII bar chart body.
+_CHART_BLOCK = "\u2588"
+
+
+def _non_ascii(text: str) -> list[str]:
+    """Distinct non-ASCII chars in ``text`` (excluding the chart block glyph)."""
+    return sorted({ch for ch in text if ord(ch) > 127 and ch != _CHART_BLOCK})
+
+
+def test_build_readme_empty_is_ascii():
+    """README rendered from zero entries contains no mojibake / non-ASCII."""
+    readme = build_readme([])
+    assert MOJIBAKE not in readme
+    assert _non_ascii(readme) == [], f"unexpected non-ASCII: {_non_ascii(readme)!r}"
+
+
+def test_build_readme_one_entry_is_ascii(one_entry):
+    """README rendered from a populated entry stays ASCII (chart block aside)."""
+    readme = build_readme(one_entry)
+    assert MOJIBAKE not in readme
+    assert _non_ascii(readme) == [], f"unexpected non-ASCII: {_non_ascii(readme)!r}"
+
+
+def test_collect_source_strings_are_ascii():
+    """The literal `source`/log strings in collect.py are mojibake-free."""
+    src = inspect.getsource(collect)
+    assert MOJIBAKE not in src, "collect.py still contains CP1252 em-dash mojibake"
+
+
+def test_generate_source_strings_are_ascii():
+    """The literal strings in generate.py are mojibake-free."""
+    import generate
+
+    src = inspect.getsource(generate)
+    assert MOJIBAKE not in src, "generate.py still contains CP1252 em-dash mojibake"
+
+
+def test_parse_index_source_label_is_ascii():
+    """parse_index_json stamps an ASCII `source` label, not mojibake."""
+    result = collect.parse_index_json(
+        {"meta": {"total": 5}, "categories": {"llm": 5}, "languages": {"Python": 5}}
+    )
+    assert MOJIBAKE not in result["source"]
+    assert _non_ascii(result["source"]) == []

--- a/tests/test_no_data_fidelity.py
+++ b/tests/test_no_data_fidelity.py
@@ -1,0 +1,107 @@
+"""No-data rendering and 'verified numbers only' fidelity tests.
+
+These pin two promises the README makes:
+
+1. generate.py must render an honest README when there is no data (no crash,
+   no fabricated numbers, explicit "no data" placeholders).
+2. collect.py must only record verified counts -- placeholder categories
+   ("tooling"/"unknown") never inflate categories_enriched, and unavailable
+   upstream sources are recorded as null rather than guessed.
+"""
+
+from __future__ import annotations
+
+from collect import parse_index_json
+from generate import _ascii_chart, _current_stats, _status_section, build_readme
+
+# -- generate.py: empty / no-data rendering --------------------------------------
+
+
+def test_build_readme_empty_does_not_crash_and_is_honest():
+    """Empty entries render a full README with explicit no-data markers."""
+    readme = build_readme([])
+    # Required structural sections still present.
+    assert "# Reporium Metrics" in readme
+    assert "## Current Stats" in readme
+    assert "## Trends" in readme
+    # Honest placeholders, not invented values.
+    assert "_No data yet._" in readme
+    # No fabricated date in the footer.
+    assert "*Last updated: n/a" in readme
+
+
+def test_current_stats_empty_is_no_data_only():
+    """_current_stats([]) returns exactly the no-data sentinel, no fake rows."""
+    result = _current_stats([])
+    assert result == "_No data yet._"
+    assert "|" not in result  # no fabricated table rows
+
+
+def test_status_section_empty_is_blank():
+    """_status_section([]) emits nothing (cannot claim what 'works' with no data)."""
+    assert _status_section([]) == ""
+
+
+def test_ascii_chart_all_none_is_no_data():
+    """A chart over all-None values shows 'No data', never a zero-height bar."""
+    result = _ascii_chart([None, None, None], ["a", "b", "c"], "Repos")
+    assert "_No data yet._" in result
+    assert "```" not in result  # no empty code-block chart rendered
+
+
+def test_ascii_chart_single_point_is_not_a_fake_trend():
+    """One data point is described, not drawn as a misleading trend chart."""
+    result = _ascii_chart([818.0], ["2026-03-17"], "Repos")
+    assert "818" in result
+    assert "multiple nightly runs" in result
+    assert "```" not in result
+
+
+def test_build_readme_none_db_entry_does_not_fabricate_repos():
+    """An entry whose reporium_db is None must not invent a repos_tracked number."""
+    entries = [{"date": "2026-04-01", "forksync_v1": None, "reporium_db": None}]
+    readme = build_readme(entries)
+    assert "2026-04-01" in readme
+    # Missing db metrics render as the '--' placeholder, never a guessed count.
+    assert "| Repos tracked (reporium-db) | -- |" in readme
+
+
+# -- collect.py: 'verified numbers only' aggregation -----------------------------
+
+
+def test_categories_enriched_excludes_placeholder_buckets():
+    """tooling/unknown are placeholders -- they never count as enrichment."""
+    data = {
+        "meta": {"total": 1000},
+        "categories": {"tooling": 600, "unknown": 400},
+        "languages": {"Python": 500},
+    }
+    result = parse_index_json(data)
+    assert result["categories_enriched"] == 0
+    assert result["repos_tracked"] == 1000
+
+
+def test_categories_enriched_counts_only_real_buckets():
+    """Only genuine category buckets contribute to categories_enriched."""
+    data = {
+        "meta": {"total": 1000},
+        "categories": {"llm": 300, "rag": 200, "tooling": 400, "unknown": 100},
+        "languages": {"Python": 500, "TypeScript": 100},
+    }
+    result = parse_index_json(data)
+    assert result["categories_enriched"] == 2  # llm + rag only
+    assert result["languages"] == 2
+
+
+def test_parse_index_missing_total_is_none_not_zero():
+    """A missing repos total is recorded as None, never silently coerced to 0."""
+    data = {"meta": {}, "categories": {"llm": 5}, "languages": {"Python": 5}}
+    result = parse_index_json(data)
+    assert result["repos_tracked"] is None
+
+
+def test_parse_index_empty_categories_is_zero_enriched():
+    """No categories at all means zero enrichment, not a fabricated count."""
+    data = {"meta": {"total": 10}, "categories": {}, "languages": {"Go": 10}}
+    result = parse_index_json(data)
+    assert result["categories_enriched"] == 0


### PR DESCRIPTION
## Summary

Hardening pass on `reporium-metrics`, branched off `main`.

1. **README mojibake fix (CP1252 em-dash -> ASCII `--`)** -- a real em-dash
   (U+2014) had been corrupted into the byte sequence `E2 80 94`, which renders
   as mojibake (`a"`...) when read back as UTF-8. The footer separator carried
   the same fault (middle-dot mojibake). Fixed in `generate.py`, `collect.py`,
   and `MILESTONES.md`; `README.md` regenerated. The rendered README is now pure
   ASCII apart from the intentional block glyph used for the trend bars.
2. **generate.py empty / no-data rendering** -- pinned the honest no-data
   contract: empty entries render a full README with explicit `_No data yet._`
   placeholders, the status section stays blank (no claims without data), single
   data points are described rather than drawn as a misleading trend, and the
   footer date sentinel reads `n/a`.
3. **collect.py "verified numbers only" aggregation** -- pinned that placeholder
   buckets (`tooling`/`unknown`) never inflate `categories_enriched`, only real
   buckets count, and a missing repos total stays `None` rather than being
   coerced to `0`.

The parser regex character classes in `collect.py` (lines that match upstream
SYNC_REPORT.md emoji/separators) are deliberately left intact -- detection logic
is unchanged. `metrics.json` (the data artifact) is intentionally untouched: its
`source` strings are internal-only and never rendered into the README.

The fourth candidate item -- "latency percentile regression over committed
fixtures" -- was assessed and **dropped as non-viable**: there is no
percentile-computing function in the codebase (`api_latency` is an opaque
pass-through where `p95_ms` arrives pre-computed from the API), and there is zero
committed latency data in `metrics.json` to regress against. Writing such a test
would require fabricating both the function and the fixtures, which is invention,
not hardening.

## Tests (test-first for the bug, mutation-checked)

- `tests/test_ascii_output.py` (5 tests) -- regression guard: `build_readme`
  output and `collect`/`generate` source literals contain no mojibake. These
  failed against `main` (red) before the fix, then passed.
- `tests/test_no_data_fidelity.py` (10 tests) -- empty/no-data rendering and
  verified-numbers aggregation.

**Mutation checks (proof of teeth):**
- Made `parse_index_json` count `tooling`/`unknown` -> fidelity tests failed
  (`assert 4 == 2`).
- Made `_current_stats([])` fabricate `9999` -> empty-render test failed.
Both reverted; suite green.

## Local validation (CI is offline -- local run is the only validation)

```
$ ruff check .
All checks passed!

$ python -m pytest -q
..........................................                               [100%]
42 passed in 0.18s
```

Baseline before this PR was 27 passed; +15 new tests.

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>

🤖 Generated with [Claude Code](https://claude.com/claude-code)
